### PR TITLE
feat: Add option to include message descriptions in export

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -66,6 +66,15 @@
       "contributions": [
         "code"
       ]
+    },
+    {
+      "login": "gmaclennan",
+      "name": "Gregor MacLennan",
+      "avatar_url": "https://avatars1.githubusercontent.com/u/290457?v=4",
+      "profile": "http://ddem.us/",
+      "contributions": [
+        "code"
+      ]
     }
   ],
   "repoType": "github"

--- a/index.js
+++ b/index.js
@@ -78,10 +78,13 @@ module.exports = async (locales, pattern, opts) => {
       plugins: resolvePlugins(plugins, babelrcDir)
     })
     const localeObj = localeMap(locales)
-    for (const { id, defaultMessage } of result['react-intl'].messages) {
+    for (const { id, defaultMessage, description } of result['react-intl']
+      .messages) {
       for (const locale of locales) {
-        localeObj[locale][id] =
-          opts.defaultLocale === locale ? defaultMessage : ''
+        const message = opts.defaultLocale === locale ? defaultMessage : ''
+        localeObj[locale][id] = opts.descriptions
+          ? { message, description }
+          : message
       }
     }
     return localeObj

--- a/readme.md
+++ b/readme.md
@@ -3,7 +3,7 @@
 [![Build Status](https://travis-ci.org/akameco/extract-react-intl.svg?branch=master)](https://travis-ci.org/akameco/extract-react-intl)
 [![tested with jest](https://img.shields.io/badge/tested_with-jest-99424f.svg)](https://github.com/facebook/jest)
 [![styled with prettier](https://img.shields.io/badge/styled_with-prettier-ff69b4.svg)](https://github.com/prettier/prettier)
-[![All Contributors](https://img.shields.io/badge/all_contributors-6-orange.svg?style=flat-square)](#contributors)
+[![All Contributors](https://img.shields.io/badge/all_contributors-7-orange.svg?style=flat-square)](#contributors)
 
 This package allows you to extract all messages from a glob. It will return an object with a key for each locale you pass, which in turn contains an object with the ids of each message defined by the [`defineMessages`](https://github.com/yahoo/react-intl/wiki/API#definemessages) function of [react-intl](https://github.com/yahoo/react-intl). The value of each of these keys will be an empty string, except for your `defaultLocale` which will be populated with the [`defaultMessage`](https://github.com/yahoo/react-intl/wiki/API#message-descriptor).
 
@@ -70,6 +70,49 @@ Type: `string`<br> Example: `./path/to/module` <br> Default: `react-intl`
 
 The ES6 module source name of the React Intl package. Defines from where _defineMessages_, `<FormattedMessage />` and `<FormattedHTMLMessage />` are imported.
 
+#### descriptions
+
+Type: `boolean`<br> Default: `false`
+
+Includes message descriptions in the returned object. Each message id property
+will be an object with properties `message` and `description` instead of a
+message string e.g.
+
+```js
+const extractReactIntl = require('extract-react-intl')
+
+const pattern = 'app/**/*.js'
+const locales = ['en', 'ja']
+
+extractReactIntl(locales, pattern).then(result => {
+  console.log(result)
+  /*
+{
+  en: {
+    'components/App/hello': {
+      message: 'hello',
+      description: 'hello message description'
+    },
+    'components/App/welcome': {
+      message: 'welcome to extract-react-intl',
+      description: 'welcome message description
+    }
+  },
+  ja: {
+    'components/App/hello': {
+      message: '',
+      description: 'hello message description'
+    },
+    'components/App/welcome': {
+      message: '',
+      description: 'welcome message description
+    }
+  }
+}
+  */
+})
+```
+
 ##### cwd
 
 Type: `string`<br> Default: `.`
@@ -85,8 +128,8 @@ Thanks goes to these wonderful people
 
 <!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
 <!-- prettier-ignore -->
-| [<img src="https://avatars2.githubusercontent.com/u/4002137?v=4" width="100px;" alt="akameco"/><br /><sub><b>akameco</b></sub>](http://akameco.github.io)<br />[💻](https://github.com/akameco/extract-react-intl/commits?author=akameco "Code") [📖](https://github.com/akameco/extract-react-intl/commits?author=akameco "Documentation") [⚠️](https://github.com/akameco/extract-react-intl/commits?author=akameco "Tests") [🚇](#infra-akameco "Infrastructure (Hosting, Build-Tools, etc)") | [<img src="https://avatars0.githubusercontent.com/u/27622?v=4" width="100px;" alt="nodaguti"/><br /><sub><b>nodaguti</b></sub>](http://about.me/nodaguti)<br />[💻](https://github.com/akameco/extract-react-intl/commits?author=nodaguti "Code") [⚠️](https://github.com/akameco/extract-react-intl/commits?author=nodaguti "Tests") | [<img src="https://avatars1.githubusercontent.com/u/11943024?v=4" width="100px;" alt="fix-fix"/><br /><sub><b>fix-fix</b></sub>](https://github.com/fix-fix)<br />[💻](https://github.com/akameco/extract-react-intl/commits?author=fix-fix "Code") | [<img src="https://avatars3.githubusercontent.com/u/1190640?v=4" width="100px;" alt="enrique-ramirez"/><br /><sub><b>enrique-ramirez</b></sub>](https://github.com/enrique-ramirez)<br />[📖](https://github.com/akameco/extract-react-intl/commits?author=enrique-ramirez "Documentation") | [<img src="https://avatars3.githubusercontent.com/u/1264276?v=4" width="100px;" alt="bradbarrow"/><br /><sub><b>bradbarrow</b></sub>](http://bradbarrow.com)<br />[🐛](https://github.com/akameco/extract-react-intl/issues?q=author%3Abradbarrow "Bug reports") [💻](https://github.com/akameco/extract-react-intl/commits?author=bradbarrow "Code") [⚠️](https://github.com/akameco/extract-react-intl/commits?author=bradbarrow "Tests") | [<img src="https://avatars1.githubusercontent.com/u/4540538?v=4" width="100px;" alt="Filip Filson Pasternak"/><br /><sub><b>Filip "Filson" Pasternak</b></sub>](https://github.com/Filson14)<br />[💻](https://github.com/akameco/extract-react-intl/commits?author=Filson14 "Code") |
-| :---: | :---: | :---: | :---: | :---: | :---: |
+| [<img src="https://avatars2.githubusercontent.com/u/4002137?v=4" width="100px;" alt="akameco"/><br /><sub><b>akameco</b></sub>](http://akameco.github.io)<br />[💻](https://github.com/akameco/extract-react-intl/commits?author=akameco "Code") [📖](https://github.com/akameco/extract-react-intl/commits?author=akameco "Documentation") [⚠️](https://github.com/akameco/extract-react-intl/commits?author=akameco "Tests") [🚇](#infra-akameco "Infrastructure (Hosting, Build-Tools, etc)") | [<img src="https://avatars0.githubusercontent.com/u/27622?v=4" width="100px;" alt="nodaguti"/><br /><sub><b>nodaguti</b></sub>](http://about.me/nodaguti)<br />[💻](https://github.com/akameco/extract-react-intl/commits?author=nodaguti "Code") [⚠️](https://github.com/akameco/extract-react-intl/commits?author=nodaguti "Tests") | [<img src="https://avatars1.githubusercontent.com/u/11943024?v=4" width="100px;" alt="fix-fix"/><br /><sub><b>fix-fix</b></sub>](https://github.com/fix-fix)<br />[💻](https://github.com/akameco/extract-react-intl/commits?author=fix-fix "Code") | [<img src="https://avatars3.githubusercontent.com/u/1190640?v=4" width="100px;" alt="enrique-ramirez"/><br /><sub><b>enrique-ramirez</b></sub>](https://github.com/enrique-ramirez)<br />[📖](https://github.com/akameco/extract-react-intl/commits?author=enrique-ramirez "Documentation") | [<img src="https://avatars3.githubusercontent.com/u/1264276?v=4" width="100px;" alt="bradbarrow"/><br /><sub><b>bradbarrow</b></sub>](http://bradbarrow.com)<br />[🐛](https://github.com/akameco/extract-react-intl/issues?q=author%3Abradbarrow "Bug reports") [💻](https://github.com/akameco/extract-react-intl/commits?author=bradbarrow "Code") [⚠️](https://github.com/akameco/extract-react-intl/commits?author=bradbarrow "Tests") | [<img src="https://avatars1.githubusercontent.com/u/4540538?v=4" width="100px;" alt="Filip "Filson" Pasternak"/><br /><sub><b>Filip "Filson" Pasternak</b></sub>](https://github.com/Filson14)<br />[💻](https://github.com/akameco/extract-react-intl/commits?author=Filson14 "Code") | [<img src="https://avatars1.githubusercontent.com/u/290457?v=4" width="100px;" alt="Gregor MacLennan"/><br /><sub><b>Gregor MacLennan</b></sub>](http://ddem.us/)<br />[💻](https://github.com/akameco/extract-react-intl/commits?author=gmaclennan "Code") |
+| :---: | :---: | :---: | :---: | :---: | :---: | :---: |
 
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 

--- a/test/__snapshots__/test.js.snap
+++ b/test/__snapshots__/test.js.snap
@@ -30,3 +30,36 @@ Object {
   },
 }
 `;
+
+exports[`extract from file with descriptions 1`] = `
+Object {
+  "en": Object {
+    "components.App.hello": Object {
+      "description": "hello message description",
+      "message": "hello",
+    },
+    "components.App.world": Object {
+      "description": "world message description",
+      "message": "world",
+    },
+    "components/Greeting/welcome": Object {
+      "description": "Welcome message description",
+      "message": "Welcome {name}, you have received {unreadCount, plural, =0 {no new messages} one {{formattedUnreadCount} new message} other {{formattedUnreadCount} new messages}} since {formattedLastLoginTime}.",
+    },
+  },
+  "ja": Object {
+    "components.App.hello": Object {
+      "description": "hello message description",
+      "message": "",
+    },
+    "components.App.world": Object {
+      "description": "world message description",
+      "message": "",
+    },
+    "components/Greeting/welcome": Object {
+      "description": "Welcome message description",
+      "message": "",
+    },
+  },
+}
+`;

--- a/test/fixtures/components/App/messages.js
+++ b/test/fixtures/components/App/messages.js
@@ -2,6 +2,8 @@
 import { defineMessages } from 'react-intl'
 
 export default defineMessages({
+  // hello message description
   hello: 'hello',
+  // world message description
   world: 'world'
 })

--- a/test/fixtures/components/Greeting/messages.js
+++ b/test/fixtures/components/Greeting/messages.js
@@ -2,6 +2,7 @@
 import { defineMessages } from 'react-intl'
 
 export default defineMessages({
+  // Welcome message description
   welcome: {
     id: 'components/Greeting/welcome',
     defaultMessage: `

--- a/test/test.js
+++ b/test/test.js
@@ -30,3 +30,12 @@ test('error', async () => {
     expect(error.message).toMatch('File not found')
   })
 })
+
+test('extract from file with descriptions', async () => {
+  process.env.BABEL_ENV = 'react-intl'
+  const x = await m(locales, pattern, {
+    cwd: './test/fixtures',
+    descriptions: true
+  })
+  expect(x).toMatchSnapshot()
+})


### PR DESCRIPTION
Adds an option `descriptions` to include the description from
`defineMessages`. Changes the returned object from `{ [locale]: message }`
to `{ [locale]: { message: message, description: description } }`

<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!
English/日本語(日本語で入力して大丈夫です。日本語の方が迅速です)
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) / 何が変更されていますか？-->
**What**:


<!-- Why are these changes necessary? / なぜその変更をする必要がありましたか？-->
**Why**:


<!-- How were these changes implemented? / これらの変更をどのように実装しましたか？-->
**How**:


**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [ ] Documentation
* [ ] Tests
* [ ] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
* [ ] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments. -->
